### PR TITLE
fixes version.yml matcher

### DIFF
--- a/tasks/version.yml
+++ b/tasks/version.yml
@@ -16,7 +16,7 @@
 
 - name: Set fact for download string
   set_fact:
-    nethermind_download_string_matcher: "nethermind-{{ 'linux' if ansible_os_family|lower != 'darwin' else 'darwin' }}-{{ 'amd64' if ansible_architecture == 'x86_64' else ansible_architecture }}"
+    nethermind_download_string_matcher: "^.*{{ 'linux' if ansible_os_family|lower != 'darwin' else 'darwin' }}-{{ '(?=amd64|x64)' if ansible_architecture == 'x86_64' else ansible_architecture }}"
 
 - debug:
     var: nethermind_download_string_matcher


### PR DESCRIPTION
fixes #2 

I decided to go with the more restrictive regex matching for this PR however an alternative is to use `(?!arm64)` instead but in the future if there's another 64 architecture it'd break this matcher again.